### PR TITLE
Fix for large (16GB) SD cards.

### DIFF
--- a/extractSD.sh
+++ b/extractSD.sh
@@ -8,6 +8,6 @@ umount $PART
 
 IMG=$1
 
-COUNT=`sudo parted /dev/mmcblk0 print | grep boot | awk '{print $3}' | awk -F'M' '{print $1}'`
+COUNT=`sudo parted /dev/mmcblk0 unit MB print | grep boot | awk '{print $3}' | awk -F'M' '{print $1}'`
 
 sudo dd if=$DISK bs=1MB count=$COUNT | pv | xz -c | dd of=$IMG


### PR DESCRIPTION
The script was failing when I tried running on a 16GB SD card. 
Added 'unit MB' to the COUNT line which forced GB to be reported as MB.
Works fine now.


